### PR TITLE
Create QuietUninstallString.

### DIFF
--- a/installer/source/Installer_src.ahk
+++ b/installer/source/Installer_src.ahk
@@ -1222,6 +1222,7 @@ _Install(opt) {
     ; Write uninstaller info.
     RegWrite REG_SZ, HKLM, %UninstallKey%, DisplayName, %ProductName% %ProductVersion%
     RegWrite REG_SZ, HKLM, %UninstallKey%, UninstallString, "%A_WorkingDir%\AutoHotkey.exe" "%A_WorkingDir%\Installer.ahk"
+    RegWrite REG_SZ, HKLM, %UninstallKey%, QuietUninstallString, "%A_WorkingDir%\AutoHotkey.exe" "%A_WorkingDir%\Installer.ahk" /Uninstall
     RegWrite REG_SZ, HKLM, %UninstallKey%, DisplayIcon, %A_WorkingDir%\AutoHotkey.exe
     RegWrite REG_SZ, HKLM, %UninstallKey%, DisplayVersion, %ProductVersion%
     RegWrite REG_SZ, HKLM, %UninstallKey%, URLInfoAbout, %ProductWebsite%


### PR DESCRIPTION
There is a convention for storing a command line for silent uninstallation in the Registry in the form of a `QuietUninstallString` value. This does not appear to be a documented feature of the Uninstall key, but is supported by software management tools and used in favor of the (likely to be interactive) `UninstallString`.

This PR adds the `QuietUninstallString` based on the [documentation](https://www.autohotkey.com/docs/Program.htm).