### PR TITLE
LeapDay; #13

### DIFF
--- a/installer/source/Lib/EnableUIAccess.ahk
+++ b/installer/source/Lib/EnableUIAccess.ahk
@@ -80,7 +80,13 @@ EnableUIAccess_CreateCert(CertName, hStore)
 
     VarSetCapacity(endTime, 16)
     DllCall("GetSystemTime", "ptr", &endTime)
-    NumPut(NumGet(endTime, "ushort") + 10, endTime, "ushort") ; += 10 years
+    NumPut(endYear:=NumGet(endTime, "ushort") + 10, endTime, "ushort") ; += 10 years
+    ;Feb29 doesn't exist after +10years https://techcommunity.microsoft.com/t5/azure-developer-community-blog/it-s-2020-is-your-code-ready-for-leap-day/ba-p/1157279#toc-hId--1858975817
+    if (NumGet(endTime, 6, "ushort")=29 && NumGet(endTime, 2, "ushort")=2) { ;wDay=29 ;wMonth=2
+        if (Mod(endYear,4) || (!Mod(endYear,100) && Mod(endYear,400))) { ;isn't LeapYear
+            NumPut(28, endTime, 6, "ushort") ; -= 1 day
+        }
+    }
 
     if !hCert := DllCall("Crypt32\CertCreateSelfSignCertificate"
         , "ptr", hProv, "ptr", &cnb, "uint", 0, "ptr", 0


### PR DESCRIPTION
https://github.com/Lexikos/AutoHotkey-Release/blob/5b4fbaf373f7269296691d5bb3f769ec32734baa/installer/source/Lib/EnableUIAccess.ahk#L83

2024-02-29 + 10 years
2034-02-29
is not a leap year

this fix is to set it to Feb28 if Feb29 doesn't exist

an alternative fix would be to always set wDay to 1 or 28

___

the cause of this issue was first found by
Glory
gloryarct
on the AutoHotkey discord server

___

I have a question: why +10 years and not +99 ?